### PR TITLE
resources section - added short, no jargon wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All the files on the local computer that should not be tracked by Git. RStudio w
 - On Windows, the Windows Credential System is often used to integrate git and GitHub together. You should delete the git entry there and then it will automatically get recreated the next time you push to GitHub (and you will be asked then to re-enter your GitHub login/pass).  
 
 ## More resources:
+- A basic no-jargon [tutorial](https://github.com/korandabit/labProtocol/blob/master/git_guide.md).
 - The official Git book from [Pro Git](https://git-scm.com/book/en/v2).
 - Resources from GitHub [link](https://help.github.com/en/github/getting-started-with-github/git-and-github-learning-resources)
 - Integrating a GitHub repository into OSF [osf link](https://help.osf.io/hc/en-us/articles/360019929813-Connect-GitHub-to-a-Project)


### PR DESCRIPTION
links to a doc in korandabit/labProtocol -- not sure if there's a simpler way to, e.g., fork/clone that document (maybe submodules?)